### PR TITLE
Fix link to Gson TypeAdapter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For this, you have two options:
 
 > Note: There is no need to implement the `write` method, since we're only consuming the API, but not sending to it.
 
-Check out this extensive [tutorial on Gson type adapters](http://www.javacreed.com/gson-typeadapter-example/).
+Check out this extensive [tutorial on Gson type adapters](http://www.javacreed.com/gson-typeadapter-example).
 
 
 ## Retrofit


### PR DESCRIPTION
This fixes the link to the Gson TypeAdapter example on javacreed.com.